### PR TITLE
Remove schema reference from wrangler configuration

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,5 +1,4 @@
 {
-  "$schema": "node_modules/wrangler/config-schema.json",
   "compatibility_date": "2026-05-23",
   "assets": {
     "directory": "./docs"


### PR DESCRIPTION
Eliminate the schema reference from the wrangler configuration file to streamline the setup.